### PR TITLE
Patch for issue #28

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -482,8 +482,11 @@ public class S3FileSystemProvider extends FileSystemProvider {
 			S3ObjectSummary objectSummary = s3ObjectSummaryLookup.lookup(s3Path);
 
 			// parse the data to BasicFileAttributes.
-			FileTime lastModifiedTime = FileTime.from(objectSummary.getLastModified().getTime(),
-					TimeUnit.MILLISECONDS);
+			FileTime lastModifiedTime = null;
+			if( objectSummary.getLastModified() != null ) {
+				lastModifiedTime = FileTime.from(objectSummary.getLastModified().getTime(), TimeUnit.MILLISECONDS);
+			}
+
 			long size =  objectSummary.getSize();
 			boolean directory = false;
 			boolean regularFile = false;
@@ -493,7 +496,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
 				directory = true;
 			}
 			// is a directory but not exists at amazon s3
-			else if (!objectSummary.getKey().equals(s3Path.getKey()) && objectSummary.getKey().startsWith(s3Path.getKey())){
+			else if ((!objectSummary.getKey().equals(s3Path.getKey()) || "".equals(s3Path.getKey())) && objectSummary.getKey().startsWith(s3Path.getKey())){
 				directory = true;
 				// no metadata, we fake one
 				size = 0;


### PR DESCRIPTION
Handle null timestamp and directory flag correctly for a S3 path contains no other component than the bucket name i.e. ``s3:///bucket/``