### PR TITLE
Fetch object metadata on Files.readAttributes operation

### DIFF
--- a/src/test/java/com/upplication/s3fs/util/AmazonS3ClientMock.java
+++ b/src/test/java/com/upplication/s3fs/util/AmazonS3ClientMock.java
@@ -205,7 +205,7 @@ public class AmazonS3ClientMock extends AmazonS3Client {
                 .getBucketName());
         s3ObjectSummary.setKey(elem.getS3Object().getKey());
         s3ObjectSummary.setLastModified(elem.getS3Object()
-                .getObjectMetadata().getLastModified());
+				.getObjectMetadata().getLastModified());
         s3ObjectSummary.setOwner(owner);
         s3ObjectSummary.setETag(elem.getS3Object()
                 .getObjectMetadata().getETag());
@@ -265,6 +265,20 @@ public class AmazonS3ClientMock extends AmazonS3Client {
         else{
             return result.getS3Object();
         }
+	}
+
+	@Override
+	public ObjectMetadata getObjectMetadata(String bucketName, String key)  {
+		S3Element result = find(bucketName, key);
+
+		if (result == null){
+			AmazonS3Exception amazonS3Exception = new AmazonS3Exception("not found with key: " + key);
+			amazonS3Exception.setStatusCode(404);
+			throw amazonS3Exception;
+		}
+		else{
+			return result.getS3Object().getObjectMetadata();
+		}
 	}
 
 	@Override
@@ -405,7 +419,7 @@ public class AmazonS3ClientMock extends AmazonS3Client {
 			object.setObjectContent(null);
 		} else {
 			metadata.setContentLength(attr.size());
-			object.setObjectContent( new ByteArrayInputStream(Files.readAllBytes(elem)));
+			object.setObjectContent(new ByteArrayInputStream(Files.readAllBytes(elem)));
 		}
 
 		object.setObjectMetadata(metadata);


### PR DESCRIPTION
Currently the entire content object is download in order to fetch an object metadata(!). This is extremely inefficient when working with large files. This pull request uses the client method `getObjectMetadata` instead. 

As side effect this solve also the issue #30 since [this method](https://github.com/pditommaso/Amazon-S3-FileSystem-NIO2/blob/patch_improved_listing/src/main/java/com/upplication/s3fs/util/S3ObjectSummaryLookup.java#L85-85) is any more required.
