### PR TITLE
Updated dependency to `aws-java-sdk-s3` instead of `aws-java-sdk`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
+			<artifactId>aws-java-sdk-s3</artifactId>
 			<version>1.9.4</version>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
The module `aws-java-sdk` depends on a dozen of other module that are not used.