### PR TITLE
Some improvements to S3SeekableByteChannel constructor

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3FileSystem.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystem.java
@@ -39,7 +39,7 @@ public class S3FileSystem extends FileSystem implements Comparable<S3FileSystem>
 	}
 
 	@Override
-	public FileSystemProvider provider() {
+	public S3FileSystemProvider provider() {
 		return provider;
 	}
 


### PR DESCRIPTION
  - don't load S3 file content completely into memory just to store it on local disk afterwards
  - remove temporary file if an exception occurs during object construction
  - remove side effects from the options parameter