### PR TITLE
Introduce S3OutputStream that uploads data to S3 directly

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3OutputStream.java
+++ b/src/main/java/com/upplication/s3fs/S3OutputStream.java
@@ -1,0 +1,361 @@
+package com.upplication.s3fs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.SequenceInputStream;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.AmazonClientException;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3ObjectId;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+
+/**
+ * Writes data directly into an Amazon S3 object.
+ */
+public final class S3OutputStream extends OutputStream {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3OutputStream.class);
+
+    /**
+     * Minimum part size of a part in a multipart upload: 5 MiB.
+     *
+     * @see  <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html">Amazon Simple Storage
+     *       Service (S3) » API Reference » REST API » Operations on Objects » Upload Part</a>
+     */
+    private static final int MIN_UPLOAD_PART_SIZE = 5 << 20;
+
+    /**
+     * Maximum number of parts that may comprise a multipart upload: 10,000.
+     *
+     * @see  <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html">Amazon Simple Storage
+     *       Service (S3) » API Reference » REST API » Operations on Objects » Upload Part</a>
+     */
+    private static final int MAX_ALLOWED_UPLOAD_PARTS = 10_000;
+
+    /**
+     * Amazon S3 API implementation to use.
+     */
+    private final AmazonS3 s3;
+
+    /**
+     * ID of the S3 object to store data into.
+     */
+    private final S3ObjectId objectId;
+
+    /**
+     * Amazon S3 storage class to apply to the newly created S3 object, if any.
+     */
+    private final StorageClass storageClass;
+
+    /**
+     * Metadata that will be attached to the stored S3 object.
+     */
+    private final ObjectMetadata metadata;
+
+    /**
+     * Indicates if the stream has been closed.
+     */
+    private volatile boolean closed;
+
+    /**
+     * Internal buffer. May be {@code null} if no bytes are buffered.
+     */
+    private byte[] buffer;
+
+    /**
+     * Number of bytes that are currently stored in the internal buffer. If {@code 0}, then {@code buffer} may also be
+     * {@code null}.
+     */
+    private int bufferSize;
+
+    /**
+     * If a multipart upload is in progress, holds the ID for it, {@code null} otherwise.
+     */
+    private String uploadId;
+
+    /**
+     * If a multipart upload is in progress, holds the ETags of the uploaded parts, {@code null} otherwise.
+     */
+    private List<PartETag> partETags;
+
+    /**
+     * Creates a new {@code S3OutputStream} that writes data directly into the S3 object with the given {@code objectId}.
+     * No special object metadata or storage class will be attached to the object.
+     *
+     * @param   s3        Amazon S3 API implementation to use
+     * @param   objectId  ID of the S3 object to store data into
+     *
+     * @throws  NullPointerException  if at least one parameter is {@code null}
+     */
+    public S3OutputStream(final AmazonS3 s3, final S3ObjectId objectId) {
+        this.s3 = requireNonNull(s3);
+        this.objectId = requireNonNull(objectId);
+        this.metadata = new ObjectMetadata();
+        this.storageClass = null;
+    }
+
+    /**
+     * Creates a new {@code S3OutputStream} that writes data directly into the S3 object with the given {@code objectId}.
+     * No special object metadata will be attached to the object.
+     *
+     * @param   s3            Amazon S3 API implementation to use
+     * @param   objectId      ID of the S3 object to store data into
+     * @param   storageClass  Amazon S3 storage class to apply to the newly created S3 object, if any
+     *
+     * @throws  NullPointerException  if at least one parameter except {@code storageClass} is {@code null}
+     */
+    public S3OutputStream(final AmazonS3 s3, final S3ObjectId objectId, final StorageClass storageClass) {
+        this.s3 = requireNonNull(s3);
+        this.objectId = requireNonNull(objectId);
+        this.storageClass = storageClass;
+        this.metadata = new ObjectMetadata();
+    }
+
+    /**
+     * Creates a new {@code S3OutputStream} that writes data directly into the S3 object with the given {@code objectId}.
+     * The given {@code metadata} will be attached to the written object. No special storage class will be set for the
+     * object.
+     *
+     * @param   s3        Amazon S3 API to use
+     * @param   objectId  ID of the S3 object to store data into
+     * @param   metadata  metadata to attach to the written object
+     *
+     * @throws  NullPointerException  if at least one parameter except {@code storageClass} is {@code null}
+     */
+    public S3OutputStream(final AmazonS3 s3, final S3ObjectId objectId, final ObjectMetadata metadata) {
+        this.s3 = requireNonNull(s3);
+        this.objectId = requireNonNull(objectId);
+        this.storageClass = null;
+        this.metadata = metadata.clone();
+    }
+
+    /**
+     * Creates a new {@code S3OutputStream} that writes data directly into the S3 object with the given {@code objectId}.
+     * The given {@code metadata} will be attached to the written object.
+     *
+     * @param   s3            Amazon S3 API to use
+     * @param   objectId      ID of the S3 object to store data into
+     * @param   storageClass  Amazon S3 storage class to apply to the newly created S3 object, if any
+     * @param   metadata      metadata to attach to the written object
+     *
+     * @throws  NullPointerException  if at least one parameter except {@code storageClass} is {@code null}
+     */
+    public S3OutputStream(final AmazonS3 s3, final S3ObjectId objectId, final StorageClass storageClass,
+            final ObjectMetadata metadata) {
+        this.s3 = requireNonNull(s3);
+        this.objectId = requireNonNull(objectId);
+        this.storageClass = storageClass;
+        this.metadata = metadata.clone();
+    }
+
+    @Override
+    public void write(final int b) throws IOException {
+        write(new byte[] {(byte) b});
+    }
+
+    @Override
+    public void write(final byte[] b, final int off, final int len) throws IOException {
+        if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) > b.length) || ((off + len) < 0)) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        if (len == 0) {
+            return;
+        }
+
+        if (closed) {
+            throw new IOException("Already closed");
+        }
+
+        synchronized (this) {
+            if (uploadId != null && partETags.size() >= MAX_ALLOWED_UPLOAD_PARTS) {
+                throw new IOException("Maximum number of upload parts reached");
+            }
+
+            if (len >= MIN_UPLOAD_PART_SIZE || bufferSize + len >= MIN_UPLOAD_PART_SIZE) {
+                uploadPart((long) bufferSize + (long) len, bufferCombinedWith(b, off, len), false);
+                bufferSize = 0;
+            } else {
+                if (buffer == null) {
+                    buffer = new byte[MIN_UPLOAD_PART_SIZE];
+                }
+
+                System.arraycopy(b, off, buffer, bufferSize, len);
+                bufferSize += len;
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+
+        synchronized (this) {
+            if (uploadId == null) {
+                putObject(bufferSize, bufferAsStream());
+                buffer = null;
+                bufferSize = 0;
+            } else {
+                uploadPart(bufferSize, bufferAsStream(), true);
+                buffer = null;
+                bufferSize = 0;
+                completeMultipartUpload();
+            }
+
+            closed = true;
+        }
+    }
+
+    private InitiateMultipartUploadResult initiateMultipartUpload() throws IOException {
+        final InitiateMultipartUploadRequest request = //
+            new InitiateMultipartUploadRequest(objectId.getBucket(), objectId.getKey(), metadata);
+
+        if (storageClass != null) {
+            request.setStorageClass(storageClass);
+        }
+
+        try {
+            return s3.initiateMultipartUpload(request);
+        } catch (final AmazonClientException e) {
+            throw new IOException("Failed to initiate Amazon S3 multipart upload", e);
+        }
+    }
+
+    private void uploadPart(final long contentLength, final InputStream content, final boolean lastPart)
+        throws IOException {
+
+        if (uploadId == null) {
+            uploadId = initiateMultipartUpload().getUploadId();
+            if (uploadId == null) {
+                throw new IOException("Failed to get a valid multipart upload ID from Amazon S3");
+            }
+
+            partETags = new ArrayList<>();
+        }
+
+        final int partNumber = partETags.size() + 1;
+
+        final UploadPartRequest request = new UploadPartRequest();
+        request.setBucketName(objectId.getBucket());
+        request.setKey(objectId.getKey());
+        request.setUploadId(uploadId);
+        request.setPartNumber(partNumber);
+        request.setPartSize(contentLength);
+        request.setInputStream(content);
+        request.setLastPart(lastPart);
+
+        LOG.debug("Uploading part {} with length {} for {} ", partNumber, contentLength, objectId);
+
+        boolean success = false;
+        try {
+            final PartETag partETag = s3.uploadPart(request).getPartETag();
+            LOG.debug("Uploaded part {} with length {} for {}: {}", //
+                partETag.getPartNumber(), contentLength, objectId, partETag.getETag());
+            partETags.add(partETag);
+
+            success = true;
+        } catch (final AmazonClientException e) {
+            throw new IOException("Failed to upload multipart data to Amazon S3", e);
+        } finally {
+            if (!success) {
+                closed = true;
+                abortMultipartUpload();
+            }
+        }
+
+        if (partNumber >= MAX_ALLOWED_UPLOAD_PARTS) {
+            close();
+        }
+    }
+
+    private void abortMultipartUpload() {
+        LOG.debug("Aborting multipart upload {} for {}", uploadId, objectId);
+        try {
+            s3.abortMultipartUpload(new AbortMultipartUploadRequest( //
+                    objectId.getBucket(), objectId.getKey(), uploadId));
+            uploadId = null;
+            partETags = null;
+        } catch (final AmazonClientException e) {
+            LOG.warn("Failed to abort multipart upload {}: {}", uploadId, e.getMessage());
+        }
+    }
+
+    private void completeMultipartUpload() throws IOException {
+        final int partCount = partETags.size();
+        LOG.debug("Completing upload to {} consisting of {} parts", objectId, partCount);
+
+        try {
+            s3.completeMultipartUpload(new CompleteMultipartUploadRequest( //
+                    objectId.getBucket(), objectId.getKey(), uploadId, partETags));
+        } catch (final AmazonClientException e) {
+            throw new IOException("Failed to complete Amazon S3 multipart upload", e);
+        }
+
+        LOG.debug("Completed upload to {} consisting of {} parts", objectId, partCount);
+
+        uploadId = null;
+        partETags = null;
+    }
+
+    private void putObject(final long contentLength, final InputStream content) throws IOException {
+
+        final ObjectMetadata meta = metadata.clone();
+        meta.setContentLength(contentLength);
+
+        final PutObjectRequest request = new PutObjectRequest( //
+                objectId.getBucket(), objectId.getKey(), content, meta);
+
+        if (storageClass != null) {
+            request.setStorageClass(storageClass);
+        }
+
+        try {
+            s3.putObject(request);
+        } catch (final AmazonClientException e) {
+            throw new IOException("Failed to put data into Amazon S3 object", e);
+        }
+    }
+
+    private InputStream bufferAsStream() {
+        if (bufferSize > 0) {
+            return new ByteArrayInputStream(buffer, 0, bufferSize);
+        }
+
+        return new InputStream() {
+            @Override
+            public int read() throws IOException {
+                return -1;
+            }
+        };
+    }
+
+    private InputStream bufferCombinedWith(final byte[] b, final int off, final int len) {
+        final ByteArrayInputStream stream = new ByteArrayInputStream(b, off, len);
+        if (bufferSize < 1) {
+            return stream;
+        }
+
+        return new SequenceInputStream(new ByteArrayInputStream(buffer, 0, bufferSize), stream);
+    }
+}

--- a/src/main/java/com/upplication/s3fs/S3Path.java
+++ b/src/main/java/com/upplication/s3fs/S3Path.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import com.amazonaws.services.s3.model.S3ObjectId;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -127,6 +128,10 @@ public class S3Path implements Path {
 	 */
 	public String getKey() {
 		return fileSystem.parts2Key(parts);
+	}
+
+	public S3ObjectId toS3ObjectId() {
+		return new S3ObjectId(fileStore.getBucket().getName(), getKey());
 	}
 
 	@Override

--- a/src/test/java/com/upplication/s3fs/S3FileSystemProviderTest.java
+++ b/src/test/java/com/upplication/s3fs/S3FileSystemProviderTest.java
@@ -421,6 +421,45 @@ public class S3FileSystemProviderTest extends S3UnitTestBase {
 	// newOutputStream 
 
 	@Test
+	public void outputStreamFileExists() throws IOException {
+		Path base = getS3Directory();
+
+		Path file = base.resolve("file1");
+		Files.createFile(file);
+
+		final String content = "sample content";
+
+		try (OutputStream stream = s3fsProvider.newOutputStream(file)) {
+			stream.write(content.getBytes());
+			stream.flush();
+			stream.close();
+		}
+		// get the input
+		byte[] buffer = Files.readAllBytes(file);
+		// check
+		assertArrayEquals(content.getBytes(), buffer);
+	}
+
+	@Test
+	public void outputStreamFileNotExists() throws IOException {
+		Path base = getS3Directory();
+
+		Path file = base.resolve("file1");
+
+		final String content = "sample content";
+
+		try (OutputStream stream = s3fsProvider.newOutputStream(file)) {
+			stream.write(content.getBytes());
+			stream.flush();
+			stream.close();
+		}
+		// get the input
+		byte[] buffer = Files.readAllBytes(file);
+		// check
+		assertArrayEquals(content.getBytes(), buffer);
+	}
+
+	@Test
 	public void outputStreamWithCreateNew() throws IOException {
 		Path base = getS3Directory();
 
@@ -467,24 +506,11 @@ public class S3FileSystemProviderTest extends S3UnitTestBase {
 		s3fsProvider.newOutputStream(file, StandardOpenOption.CREATE_NEW);
 	}
 
-	@Test
+	@Test(expected = FileAlreadyExistsException.class)
 	public void outputStreamWithCreateAndFileExists() throws IOException {
 		Path base = getS3Directory();
-
-		Path file = base.resolve("file1");
-		Files.createFile(file);
-
-		final String content = "sample content";
-
-		try (OutputStream stream = s3fsProvider.newOutputStream(file, StandardOpenOption.CREATE)) {
-			stream.write(content.getBytes());
-			stream.flush();
-			stream.close();
-		}
-		// get the input
-		byte[] buffer = Files.readAllBytes(file);
-		// check
-		assertArrayEquals(content.getBytes(), buffer);
+		Path file = Files.createFile(base.resolve("file1"));
+		s3fsProvider.newOutputStream(file, StandardOpenOption.CREATE);
 	}
 
 	@Test

--- a/src/test/java/com/upplication/s3fs/S3OutputStreamTest.java
+++ b/src/test/java/com/upplication/s3fs/S3OutputStreamTest.java
@@ -1,0 +1,205 @@
+package com.upplication.s3fs;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.mockito.Matchers.any;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.junit.runner.RunWith;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+
+import org.mockito.invocation.InvocationOnMock;
+
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.mockito.stubbing.Answer;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3ObjectId;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+
+import com.google.common.io.ByteStreams;
+
+@RunWith(MockitoJUnitRunner.class)
+public class S3OutputStreamTest {
+
+    @Mock
+    private AmazonS3 s3;
+
+    @Captor
+    private ArgumentCaptor<PutObjectRequest> putObjectCaptor;
+
+    @Captor
+    private ArgumentCaptor<CompleteMultipartUploadRequest> completeMultipartUploadCaptor;
+
+    private final S3ObjectId objectId = new S3ObjectId("test", "object");
+
+    private String uploadId;
+    private boolean lastUploadPartSeen;
+    private byte[] uploadedParts;
+
+    private S3OutputStream underTest;
+
+    @Before
+    public void initializeTest() {
+        when(s3.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class))).thenAnswer(new InitiateMultipartUploadHandler());
+        when(s3.uploadPart(any(UploadPartRequest.class))).thenAnswer(new UploadPartHandler());
+        when(s3.completeMultipartUpload(any(CompleteMultipartUploadRequest.class))).thenAnswer(new CompleteMultipartUploadHandler());
+        underTest = new S3OutputStream(s3, objectId);
+    }
+
+    @Test
+    public void openAndCloseProducesEmptyObject() throws IOException {
+        underTest.close();
+        assertThatBytesHaveBeenPut(new byte[0]);
+    }
+
+    @Test
+    public void zeroBytesWrittenProduceEmptyObject() throws IOException {
+        underTest.write(new byte[0]);
+        underTest.close();
+        assertThatBytesHaveBeenPut(new byte[0]);
+    }
+
+    @Test
+    public void smallDataUsesPutObject() throws IOException {
+        final byte[] data = newRandomData(64);
+
+        underTest.write(data);
+        underTest.close();
+        assertThatBytesHaveBeenPut(data);
+    }
+
+    @Test
+    public void bigDataDataUsesMultipartUpload() throws IOException {
+        final int sixMiB = 6 * 1024 * 1024;
+        final int threeMiB = 3 * 1024 * 1024;
+
+        final byte[] data = newRandomData(sixMiB);
+
+        underTest.write(data, 0, threeMiB);
+        underTest.write(data, threeMiB, threeMiB);
+        underTest.close();
+        assertThatBytesHaveBeenUploaded(data);
+        assertThat("Multipart upload didn't have a last part", lastUploadPartSeen);
+    }
+
+    private void assertThatBytesHaveBeenPut(final byte[] data) throws IOException {
+        verify(s3).putObject(putObjectCaptor.capture());
+        verifyNoMoreInteractions(s3);
+
+        final PutObjectRequest putObjectRequest = putObjectCaptor.getValue();
+        assertThat(putObjectRequest.getMetadata().getContentLength(), is((long) data.length));
+
+        final byte[] putData;
+        try(final InputStream stream = putObjectCaptor.getValue().getInputStream()) {
+            putData = new byte[data.length];
+            ByteStreams.readFully(stream, putData);
+            assertThat(stream.read(), is(-1));
+        }
+
+        assertThat("Mismatch between expected content and actual content", Arrays.equals(data, putData));
+    }
+
+    private void assertThatBytesHaveBeenUploaded(final byte[] data) {
+        final InOrder inOrder = inOrder(s3);
+
+        inOrder.verify(s3).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+        inOrder.verify(s3, atLeastOnce()).uploadPart(any(UploadPartRequest.class));
+        inOrder.verify(s3).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+        inOrder.verifyNoMoreInteractions();
+
+        assertThat("Mismatch between expected content and actual content", Arrays.equals(data, uploadedParts));
+    }
+
+    private int resizeUploadedPartsBy(final int contentLength) {
+        if (uploadedParts == null) {
+            uploadedParts = new byte[contentLength];
+            return 0;
+        }
+
+        final int offset = uploadedParts.length;
+        uploadedParts = Arrays.copyOf(uploadedParts, offset + contentLength);
+        return offset;
+    }
+
+    private static byte[] newRandomData(final int size) {
+        final byte[] data = new byte[size];
+        new Random().nextBytes(data);
+        return data;
+    }
+
+    private final class InitiateMultipartUploadHandler implements Answer<InitiateMultipartUploadResult> {
+        @Override
+        public InitiateMultipartUploadResult answer(final InvocationOnMock invocation) throws Throwable {
+            uploadId = UUID.randomUUID().toString();
+            lastUploadPartSeen = false;
+            uploadedParts = null;
+
+            final InitiateMultipartUploadResult result = new InitiateMultipartUploadResult();
+            result.setUploadId(uploadId);
+            return result;
+        }
+    }
+
+    private final class UploadPartHandler implements Answer<UploadPartResult> {
+        @Override
+        public UploadPartResult answer(final InvocationOnMock invocation) throws IOException {
+            final UploadPartRequest request = (UploadPartRequest) invocation.getArguments()[0];
+
+            if (uploadId != null && uploadId.equals(request.getUploadId())) {
+                assertThat("Already processed last part of this multipart upload", !lastUploadPartSeen);
+                lastUploadPartSeen = request.isLastPart();
+
+                final int partSize = (int) request.getPartSize();
+                final int offset = resizeUploadedPartsBy(partSize);
+                try(final InputStream in = request.getInputStream()) {
+                    ByteStreams.readFully(in, uploadedParts, offset, partSize);
+                    assertThat(in.read(), is(-1));
+                }
+            }
+
+            return new UploadPartResult();
+        }
+    }
+
+    private final class CompleteMultipartUploadHandler implements Answer<CompleteMultipartUploadResult> {
+        @Override
+        public CompleteMultipartUploadResult answer(final InvocationOnMock invocation) throws Throwable {
+            final CompleteMultipartUploadRequest request = (CompleteMultipartUploadRequest) invocation.getArguments()[0];
+
+            if (uploadId != null && uploadId.equals(request.getUploadId())) {
+                uploadId = null;
+            }
+
+            return new CompleteMultipartUploadResult();
+        }
+    }
+}

--- a/src/test/java/com/upplication/s3fs/util/AmazonS3ClientMock.java
+++ b/src/test/java/com/upplication/s3fs/util/AmazonS3ClientMock.java
@@ -930,7 +930,7 @@ public class AmazonS3ClientMock implements AmazonS3 {
 
 	@Override
 	public PutObjectResult putObject(PutObjectRequest putObjectRequest) throws AmazonClientException, AmazonServiceException {
-		throw new UnsupportedOperationException();
+		return putObject(putObjectRequest.getBucketName(), putObjectRequest.getKey(), putObjectRequest.getInputStream(), putObjectRequest.getMetadata());
 	}
 
 	@Override


### PR DESCRIPTION
- S3OutputStream uses multipart uploads to transfer data to S3 without storing it on local disk first
- FileSystemProvider returns this implementation for new OutputStreams instead of S3SeekableByteChannel if possible
