### PR TITLE
Fix for key lookup of getFileSystem()

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -235,9 +235,16 @@ public class S3FileSystemProvider extends FileSystemProvider {
         return System.getenv(key);
     }
 
+	/**
+	 * Get existing filesystem based on a combination of URI and env settings. Create new filesystem otherwise.
+	 * @param uri URI of existing, or to be created filesystem.
+	 * @param env environment settings.
+	 * @return new or existing filesystem.
+	 */
 	public FileSystem getFileSystem(URI uri, Map<String, ?> env) {
 		validateUri(uri);
-		String key = this.getFileSystemKey(uri);
+		Properties props = getProperties(uri, env);
+		String key = this.getFileSystemKey(uri, props); // s3fs_access_key is part of the key here.
 		if (fileSystems.containsKey(key))
 			return fileSystems.get(key);
 		return newFileSystem(uri, env);

--- a/src/test/java/com/upplication/s3fs/S3FileSystemProviderWithoutMocksTest.java
+++ b/src/test/java/com/upplication/s3fs/S3FileSystemProviderWithoutMocksTest.java
@@ -1,0 +1,39 @@
+package com.upplication.s3fs;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+/**
+ * Like {@link S3FileSystemProviderTest}, but without mocks.
+ */
+public class S3FileSystemProviderWithoutMocksTest extends S3UnitTestBase {
+
+    private S3FileSystemProvider s3fsProvider;
+
+    @Before
+    public void setup() {
+        s3fsProvider = new S3FileSystemProvider();
+    }
+
+    @Test
+    public void getFileSystemWithEnv() {
+        Map<String, Object> env = ImmutableMap.<String, Object> of("s3fs_access_key", "a", "s3fs_secret_key", "b");
+        FileSystem fileSystem = s3fsProvider.getFileSystem(S3_GLOBAL_URI, env);
+        assertNotNull(fileSystem);
+        try {
+            FileSystem sameFileSystem = s3fsProvider.getFileSystem(S3_GLOBAL_URI, env);
+            assertSame(fileSystem, sameFileSystem);
+        } catch (FileSystemAlreadyExistsException fsaee) {
+            fail("A filesystem should not be created multiple times");
+        }
+    }
+}


### PR DESCRIPTION
`S3FileSystemProvider#getFileSystem()` contains a bug. It does not resolve the correct filesystem key when the `s3fs_access_key` is not set in the Properties.