### PR TITLE
Cache S3FileAttributes in S3Path instances to dramatically reduce requests to S3

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3Iterator.java
+++ b/src/main/java/com/upplication/s3fs/S3Iterator.java
@@ -16,6 +16,8 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import static com.upplication.s3fs.util.S3Utils.toS3FileAttributes;
+
 /**
  * S3 iterator over folders at first level.
  * Future versions of this class should be return the elements
@@ -118,7 +120,6 @@ public class S3Iterator implements Iterator<Path> {
         items.addAll(parentPaths);
     }
 
-
     /**
      * add to the listPath the elements at the same level that s3Path
      * @param key the uri to parse
@@ -138,6 +139,7 @@ public class S3Iterator implements Iterator<Path> {
             String immediateDescendantKey = getImmediateDescendant(key, objectSummaryKey);
             if (immediateDescendantKey != null) {
                 S3Path descendentPart = new S3Path(fileSystem, fileStore, fileSystem.key2Parts(immediateDescendantKey));
+                descendentPart.setFileAttributes(toS3FileAttributes(objectSummary));
 
                 if (!listPath.contains(descendentPart)) {
                     listPath.add(descendentPart);

--- a/src/main/java/com/upplication/s3fs/S3Iterator.java
+++ b/src/main/java/com/upplication/s3fs/S3Iterator.java
@@ -139,7 +139,7 @@ public class S3Iterator implements Iterator<Path> {
             String immediateDescendantKey = getImmediateDescendant(key, objectSummaryKey);
             if (immediateDescendantKey != null) {
                 S3Path descendentPart = new S3Path(fileSystem, fileStore, fileSystem.key2Parts(immediateDescendantKey));
-                descendentPart.setFileAttributes(toS3FileAttributes(objectSummary));
+                descendentPart.setFileAttributes(toS3FileAttributes(objectSummary, immediateDescendantKey));
 
                 if (!listPath.contains(descendentPart)) {
                     listPath.add(descendentPart);

--- a/src/main/java/com/upplication/s3fs/S3Path.java
+++ b/src/main/java/com/upplication/s3fs/S3Path.java
@@ -57,6 +57,8 @@ public class S3Path implements Path {
 	 */
 	private S3FileSystem fileSystem;
 
+	private S3FileAttributes fileAttributes;
+
 	/**
 	 * path must be a string of the form "/{bucket}", "/{bucket}/{key}" or just
 	 * "{key}".
@@ -453,6 +455,18 @@ public class S3Path implements Path {
 				return input != null && !input.isEmpty();
 			}
 		};
+	}
+
+	public boolean hasFileAttributes() {
+		return fileAttributes != null;
+	}
+
+	public S3FileAttributes getFileAttributes() {
+		return fileAttributes;
+	}
+
+	public void setFileAttributes(S3FileAttributes fileAttributes) {
+		this.fileAttributes = fileAttributes;
 	}
 
 	/*

--- a/src/main/java/com/upplication/s3fs/util/S3Utils.java
+++ b/src/main/java/com/upplication/s3fs/util/S3Utils.java
@@ -62,7 +62,7 @@ public class S3Utils {
      */
     public S3FileAttributes getS3FileAttributes(S3Path s3Path) throws NoSuchFileException {
         if (!s3Path.hasFileAttributes()) {
-            s3Path.setFileAttributes(toS3FileAttributes(getS3ObjectSummary(s3Path)));
+            s3Path.setFileAttributes(toS3FileAttributes(getS3ObjectSummary(s3Path), s3Path.getKey()));
         }
         return s3Path.getFileAttributes();
     }
@@ -72,7 +72,7 @@ public class S3Utils {
      * @param objectSummary S3ObjectSummary mandatory not null
      * @return S3FileAttributes
      */
-    public static S3FileAttributes toS3FileAttributes(S3ObjectSummary objectSummary) {
+    public static S3FileAttributes toS3FileAttributes(S3ObjectSummary objectSummary, String key) {
         // parse the data to BasicFileAttributes.
         FileTime lastModifiedTime = null;
         if (objectSummary.getLastModified() != null){
@@ -83,20 +83,19 @@ public class S3Utils {
         boolean regularFile = false;
         String resolvedKey = objectSummary.getKey();
         // check if is a directory and exists the key of this directory at amazon s3
-        if (objectSummary.getKey().endsWith("/") && resolvedKey.equals(objectSummary.getKey()) ||
-                resolvedKey.equals(objectSummary.getKey() + "/")) {
+        if (key.endsWith("/") && resolvedKey.equals(key) ||
+                resolvedKey.equals(key + "/")) {
             directory = true;
-        }
-        else if (objectSummary.getKey().isEmpty()) { // is a bucket (no key)
+        } else if (key.isEmpty()) { // is a bucket (no key)
             directory = true;
             resolvedKey = "/";
         }
-        else if (!resolvedKey.equals(objectSummary.getKey()) && resolvedKey.startsWith(objectSummary.getKey())) { // is a directory but not exists at amazon s3
+        else if (!resolvedKey.equals(key) && resolvedKey.startsWith(key)) { // is a directory but not exists at amazon s3
             directory = true;
             // no metadata, we fake one
             size = 0;
             // delete extra part
-            resolvedKey = objectSummary.getKey() + "/";
+            resolvedKey = key + "/";
         } else {
             regularFile = true;
         }

--- a/src/main/java/com/upplication/s3fs/util/S3Utils.java
+++ b/src/main/java/com/upplication/s3fs/util/S3Utils.java
@@ -61,7 +61,10 @@ public class S3Utils {
      * @return S3FileAttributes
      */
     public S3FileAttributes getS3FileAttributes(S3Path s3Path) throws NoSuchFileException {
-        return toS3FileAttributes(getS3ObjectSummary(s3Path));
+        if (!s3Path.hasFileAttributes()) {
+            s3Path.setFileAttributes(toS3FileAttributes(getS3ObjectSummary(s3Path)));
+        }
+        return s3Path.getFileAttributes();
     }
 
     /**


### PR DESCRIPTION
Given this code snippet running with S3-FileSystem:

`List<Path> files = Files.walk(folder, 1).filter(Files::isRegularFile).collect(Collectors.toList());`

It makes four (!) S3 HTTP requests per each directory entry (files and immediate subfolders).

With this pull request, the number of S3 HTTP requests is reduced to 1 + N x 2, where N is the number of immediate subfolders.

For a folder containing 10 000 files but no subfolders, the change is 40 000 -> 1 :zap: 