### PR TITLE
Implement S3FileSystemProvider.move() simply with copy() and delete()

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -395,7 +395,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
 
 	@Override
 	public void move(Path source, Path target, CopyOption... options) throws IOException {
-		throw new UnsupportedOperationException();
+		copy(source, target, options);
+		delete(source);
 	}
 
 	@Override

--- a/src/test/java/com/upplication/s3fs/S3FileSystemProviderTest.java
+++ b/src/test/java/com/upplication/s3fs/S3FileSystemProviderTest.java
@@ -922,7 +922,7 @@ public class S3FileSystemProviderTest extends S3UnitTestBase {
 		s3fsProvider.copy(file, fileDest);
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void move() throws IOException {
 		// fixtures
 		AmazonS3ClientMock client = AmazonS3MockFactory.getAmazonClientMock();


### PR DESCRIPTION
Simple implementation of move/rename for files. Works for me at least :)

copy + delete seems to be the way Amazon recommends rename/move to be implemented anyway.