### PR TITLE
Support for URIs with custom ports

### DIFF
--- a/src/main/java/com/upplication/s3fs/AmazonS3Factory.java
+++ b/src/main/java/com/upplication/s3fs/AmazonS3Factory.java
@@ -52,8 +52,14 @@ public abstract class AmazonS3Factory {
 
     public AmazonS3 getAmazonS3(URI uri, Properties props) {
         AmazonS3 client = createAmazonS3(getCredentialsProvider(props), getClientConfiguration(props), getRequestMetricsCollector(props));
-        if (uri.getHost() != null)
-            client.setEndpoint(uri.getHost());
+        if (uri.getHost() != null) {
+            if (uri.getPort() != -1) {
+                client.setEndpoint(uri.getHost() + ":" + String.valueOf(uri.getPort()));
+            }
+            else {
+                client.setEndpoint(uri.getHost());
+            }
+        }
         return client;
     }
 


### PR DESCRIPTION
Detect if the incoming URI has a non-default port and format the endpoint appropriately. Can be used against non-AWS S3 clouds.

One thing I'm unsure of is how to unit test this.  For integration tests, I could just look out references to S3_GLOBAL_URI_IT and duplicate it using a URI that has ":443" appended to the end and that will likely work. But for unit tests, there is no getEndpoint() call. From what I can tell the endpoint after set is not public accessible.

Let me know what you want me to do about adding unit and it tests.