### PR TITLE
Add support for overriding S3 port

### DIFF
--- a/src/main/java/com/upplication/s3fs/AmazonS3Factory.java
+++ b/src/main/java/com/upplication/s3fs/AmazonS3Factory.java
@@ -52,8 +52,12 @@ public abstract class AmazonS3Factory {
 
     public AmazonS3 getAmazonS3(URI uri, Properties props) {
         AmazonS3 client = createAmazonS3(getCredentialsProvider(props), getClientConfiguration(props), getRequestMetricsCollector(props));
-        if (uri.getHost() != null)
-            client.setEndpoint(uri.getHost());
+        if (uri.getHost() != null) {
+            if (uri.getPort() != -1)
+                client.setEndpoint(uri.getHost() + ':' + uri.getPort());
+            else
+                client.setEndpoint(uri.getHost());
+        }
         return client;
     }
 

--- a/src/test/java/com/upplication/s3fs/AmazonS3ClientFactoryTest.java
+++ b/src/test/java/com/upplication/s3fs/AmazonS3ClientFactoryTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URI;
 import java.util.Properties;
 
 import com.upplication.s3fs.util.S3EndpointConstant;
@@ -161,5 +162,17 @@ public class AmazonS3ClientFactoryTest {
         ClientConfiguration clientConfiguration = client.getClientConfiguration();
         assertEquals(0, clientConfiguration.getSocketBufferSizeHints()[0]);
         assertEquals(54321, clientConfiguration.getSocketBufferSizeHints()[1]);
+    }
+
+    @Test
+    public void overrideHostAndPort() throws Exception {
+        AmazonS3ClientFactory clientFactory = new ExposingAmazonS3ClientFactory();
+        System.setProperty(ACCESS_KEY_SYSTEM_PROPERTY, "test");
+        System.setProperty(SECRET_KEY_SYSTEM_PROPERTY, "test");
+        ExposingAmazonS3Client client = (ExposingAmazonS3Client) clientFactory.getAmazonS3(URI.create("s3://localhost:8001/"), new Properties());
+        URI endpoint = client.getEndpoint();
+        assertEquals("https", endpoint.getScheme());
+        assertEquals("localhost", endpoint.getHost());
+        assertEquals(8001, endpoint.getPort());
     }
 }

--- a/src/test/java/com/upplication/s3fs/util/ExposingAmazonS3Client.java
+++ b/src/test/java/com/upplication/s3fs/util/ExposingAmazonS3Client.java
@@ -1,5 +1,6 @@
 package com.upplication.s3fs.util;
 
+import java.net.URI;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.metrics.RequestMetricCollector;
@@ -23,5 +24,9 @@ public class ExposingAmazonS3Client extends AmazonS3Client {
 
     public RequestMetricCollector getRequestMetricCollector() {
         return super.requestMetricCollector();
+    }
+
+    public URI getEndpoint() {
+        return endpoint;
     }
 }


### PR DESCRIPTION
This allows a port number to also be specified in the initial URI
provided to FileSystems.newFileSystem() to aid in testing. For example,
a mock S3 server can be run within an integration test which generally
doesn't run on privileged ports like 80 or 443. See related project:
<https://github.com/findify/s3mock>.