### PR TITLE
Add support for overriding Signer

### DIFF
--- a/src/main/java/com/upplication/s3fs/AmazonS3Factory.java
+++ b/src/main/java/com/upplication/s3fs/AmazonS3Factory.java
@@ -34,6 +34,7 @@ public abstract class AmazonS3Factory {
     public static final String SOCKET_RECEIVE_BUFFER_SIZE_HINT = "s3fs_socket_receive_buffer_size_hint";
     public static final String SOCKET_TIMEOUT = "s3fs_socket_timeout";
     public static final String USER_AGENT = "s3fs_user_agent";
+    public static final String SIGNER_OVERRIDE = "s3fs_signer_override";
 
     /**
      * Build a new Amazon S3 instance with the URI and the properties provided
@@ -116,6 +117,8 @@ public abstract class AmazonS3Factory {
             clientConfiguration.setSocketTimeout(Integer.parseInt(props.getProperty(SOCKET_TIMEOUT)));
         if (props.getProperty(USER_AGENT) != null)
             clientConfiguration.setUserAgentPrefix(props.getProperty(USER_AGENT));
+        if(props.getProperty(SIGNER_OVERRIDE) != null)
+            clientConfiguration.setSignerOverride(props.getProperty(SIGNER_OVERRIDE));
         return clientConfiguration;
     }
 

--- a/src/test/java/com/upplication/s3fs/AmazonS3ClientFactoryTest.java
+++ b/src/test/java/com/upplication/s3fs/AmazonS3ClientFactoryTest.java
@@ -19,6 +19,7 @@ import static com.upplication.s3fs.AmazonS3Factory.SOCKET_RECEIVE_BUFFER_SIZE_HI
 import static com.upplication.s3fs.AmazonS3Factory.SOCKET_SEND_BUFFER_SIZE_HINT;
 import static com.upplication.s3fs.AmazonS3Factory.SOCKET_TIMEOUT;
 import static com.upplication.s3fs.AmazonS3Factory.USER_AGENT;
+import static com.upplication.s3fs.AmazonS3Factory.SIGNER_OVERRIDE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -58,6 +59,7 @@ public class AmazonS3ClientFactoryTest {
         props.setProperty(SOCKET_RECEIVE_BUFFER_SIZE_HINT, "49000");
         props.setProperty(SOCKET_TIMEOUT, "30");
         props.setProperty(USER_AGENT, "I-am-Groot");
+        props.setProperty(SIGNER_OVERRIDE, "S3SignerType");
         ExposingAmazonS3Client client = (ExposingAmazonS3Client) clientFactory.getAmazonS3(S3EndpointConstant.S3_GLOBAL_URI_TEST, props);
         AWSCredentialsProvider credentialsProvider = client.getAWSCredentialsProvider();
         AWSCredentials credentials = credentialsProvider.getCredentials();
@@ -79,6 +81,7 @@ public class AmazonS3ClientFactoryTest {
         assertEquals(49000, clientConfiguration.getSocketBufferSizeHints()[1]);
         assertEquals(30, clientConfiguration.getSocketTimeout());
         assertEquals("I-am-Groot", clientConfiguration.getUserAgent());
+        assertEquals("S3SignerType", clientConfiguration.getSignerOverride());
     }
 
     @Test
@@ -108,6 +111,7 @@ public class AmazonS3ClientFactoryTest {
         assertEquals(0, clientConfiguration.getSocketBufferSizeHints()[1]);
         assertEquals(50000, clientConfiguration.getSocketTimeout());
         assertTrue(clientConfiguration.getUserAgent().startsWith("aws-sdk-java"));
+        assertNull(clientConfiguration.getSignerOverride());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This allows a Signer to also be specified, like "S3SignerType", which is needed on some CEPH-S3 compatible configurations.