### PR TITLE
fixed issue with spaces in the file name

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3Path.java
+++ b/src/main/java/com/upplication/s3fs/S3Path.java
@@ -465,7 +465,7 @@ public class S3Path implements Path {
             return URI.create("s3://" + normalizeURI(builder.toString()));
         }
         else {
-            return URI.create(this.uri);
+            return URI.create(uri);
         }
     }
 

--- a/src/test/java/com/upplication/s3fs/Path/ToUriTest.java
+++ b/src/test/java/com/upplication/s3fs/Path/ToUriTest.java
@@ -73,6 +73,15 @@ public class ToUriTest extends S3UnitTestBase {
     }
 
     @Test
+    public void toUriRelativeWithSpaces() {
+        S3FileSystem fileSystem = s3fsProvider.getFileSystem(S3_GLOBAL_URI_TEST);
+        String fileName = "file with.spaces";
+        S3Path path = new S3Path(fileSystem, fileName);
+        URI uri = path.toUri();
+        assertEquals(fileName,  uri.getPath());
+    }
+
+    @Test
     public void toUriBucketWithoutEndSlash() {
         S3Path s3Path = getPath("/bucket");
 


### PR DESCRIPTION
I'm using s3fs with Apache sshd server, and there is an 
java.lang.IllegalArgumentException: Illegal character in path at index ... 
exception when file name contains spaces, because in the S3Path toUri() method is used not encoded uri value for relative path.