### PR TITLE
Support for user-specified AWS credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Complete settings lists:
 
 * s3fs_access_key
 * s3fs_secret_key
+* s3fs_credentials_provider
 * s3fs_request_metric_collector_class
 * s3fs_connection_timeout
 * s3fs_max_connections
@@ -163,7 +164,7 @@ private FileSystem s3FileSystem;
 
 #### Roadmap:
 
-* Performance issue (slow querys with virtual folders, add multipart submit...)
+* Performance issue (slow queries with virtual folders, add multipart submit...)
 * Disallow upload binary files with same name as folders and vice versa
 
 #### Out of Roadmap:


### PR DESCRIPTION
Adds support for passing in a credentials provider using the `s3fs_credentials_provider` property.

This is useful if you are assuming a role, which requires refreshable credentials from STS using a `STSAssumeRoleSessionCredentialsProvider`. This would enable segregation using a separate AWS role per customer, with each role only having permissions to access their own objects in the bucket.

e.g.
```      
STSAssumeRoleSessionCredentialsProvider credentialsProvider = new STSAssumeRoleSessionCredentialsProvider.Builder(
          roleArn,
          "sftp-server")
          .withExternalId("external-id")
          .withRoleSessionDurationSeconds(3600)
          .build();

```