### PR TITLE
[SECURITY] Upgrade guava to 25.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.surfire.plugin.version>2.7.1</maven.surfire.plugin.version>
 		<slf4j.version>1.7.5</slf4j.version>
 		<com.amazonaws.aws-java-sdk-s3.version>1.11.232</com.amazonaws.aws-java-sdk-s3.version>
-        <com.google.guava.guava.version>18.0</com.google.guava.guava.version>
+        <com.google.guava.guava.version>25.1-jre</com.google.guava.guava.version>
         <org.apache.tika.tika-core.version>1.5</org.apache.tika.tika-core.version>
         <com.google.code.findbugs.jsr305.version>1.3.9</com.google.code.findbugs.jsr305.version>
 	</properties>


### PR DESCRIPTION
Guava 18.0 is susceptible to CWE-502: Deserialization of Untrusted Data
* https://cwe.mitre.org/data/definitions/502.html
* https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236