### PR TITLE
Update S3Utils.java

### DIFF
--- a/src/main/java/com/upplication/s3fs/util/S3Utils.java
+++ b/src/main/java/com/upplication/s3fs/util/S3Utils.java
@@ -105,7 +105,10 @@ public class S3Utils {
             userPrincipal = new S3UserPrincipal(owner.getId() + ":" + owner.getDisplayName());
             permissions = toPosixFilePermissions(acl.getGrantsAsList());
         }
-
+        
+        else {
+            permissions = toPosixFilePermission(Permission.FullControl);
+        }
         return new S3PosixFileAttributes((String)attrs.fileKey(), attrs.lastModifiedTime(),
                 attrs.size(), attrs.isDirectory(), attrs.isRegularFile(), userPrincipal, null, permissions);
     }


### PR DESCRIPTION
if the attrs.isDirectory, give it full permissions control, so we don't get a NullPointerException because we did not initialize the permissions