### PR TITLE
Fix "File name too long" errors

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3Channel.java
+++ b/src/main/java/com/upplication/s3fs/S3Channel.java
@@ -1,0 +1,18 @@
+
+package com.upplication.s3fs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+abstract class S3Channel {
+    /**
+     * Create a temporary place for the S3 file on the local filesystem, with the s3 filename mixed in
+     * e.g. "/tmp/script-tempSuffix"
+     * @param path S3 path to create a file for
+     * @return Path on the local filesystem to the temporary file that was created
+     */
+    static Path createTempFile(S3Path path) throws IOException {
+        return Files.createTempFile(path.getFileName().toString(), "");
+    }
+}

--- a/src/main/java/com/upplication/s3fs/S3FileChannel.java
+++ b/src/main/java/com/upplication/s3fs/S3FileChannel.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.upplication.s3fs.S3Channel.createTempFile;
 import static java.lang.String.format;
 
 public class S3FileChannel extends FileChannel {
@@ -38,7 +39,7 @@ public class S3FileChannel extends FileChannel {
                 !this.options.contains(StandardOpenOption.CREATE))
             throw new NoSuchFileException(format("target not exists: %s", path));
 
-        tempFile = Files.createTempFile("temp-s3-", key.replaceAll("/", "_"));
+        tempFile = createTempFile(path);
         boolean removeTempFile = true;
         try {
             if (exists) {

--- a/src/main/java/com/upplication/s3fs/S3SeekableByteChannel.java
+++ b/src/main/java/com/upplication/s3fs/S3SeekableByteChannel.java
@@ -1,5 +1,6 @@
 package com.upplication.s3fs;
 
+import static com.upplication.s3fs.S3Channel.createTempFile;
 import static java.lang.String.format;
 
 import java.io.BufferedInputStream;
@@ -43,7 +44,7 @@ public class S3SeekableByteChannel implements SeekableByteChannel {
                 !this.options.contains(StandardOpenOption.CREATE))
             throw new NoSuchFileException(format("target not exists: %s", path));
 
-        tempFile = Files.createTempFile("temp-s3-", key.replaceAll("/", "_"));
+        tempFile = createTempFile(path);
         boolean removeTempFile = true;
         try {
             if (exists) {


### PR DESCRIPTION
The Cromwell bug report https://github.com/broadinstitute/cromwell/issues/4279 relates to the way this library constructs names for its temporary files, specifically they can end up being very long.

A code change to resolve the issue came out of the Cromwell AWS Hackathon on 4/18 and was implemented in Cromwell as https://github.com/broadinstitute/cromwell/pull/4858

This PR ports that fix into code's original repo, with a small adaptation for Java 7 compatibility.